### PR TITLE
Revert k8s/ingress-service.yml to instructor version compatible with …

### DIFF
--- a/k8s/ingress-service.yml
+++ b/k8s/ingress-service.yml
@@ -1,27 +1,23 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ingress-service
   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    # UPDATE THIS LINE ABOVE
 spec:
   rules:
-    - host: k8s.local
-      http:
+    - http:
         paths:
           - path: /?(.*)
-            pathType: Exact
+            # UPDATE THIS LINE ABOVE
             backend:
-              service:
-                name: client-cluster-ip-service
-                port:
-                  number: 3000
+              serviceName: client-cluster-ip-service
+              servicePort: 3000
           - path: /api/?(.*)
-            pathType: Exact
+            # UPDATE THIS LINE ABOVE
             backend:
-              service:
-                name: server-cluster-ip-service
-                port:
-                  number: 5000
+              serviceName: server-cluster-ip-service
+              servicePort: 5000


### PR DESCRIPTION
…older k8s

big kubernetes apiVersion changes made the instructor's ingress-service incompatible with k8s v1.19. I created a new version of this conf to work locally on microk8s. Reverting back to instructor's version to make compatible with GCP.